### PR TITLE
Add full padding insted of padding-top on zui table icon

### DIFF
--- a/src/libs/css/app.css
+++ b/src/libs/css/app.css
@@ -279,7 +279,7 @@
 .zui-table_icon > div > * {
   width: 36px;
   height: 36px;
-  padding-top: 6px;
+  padding: 6px;
 }
 
 .zui-table_cell {


### PR DESCRIPTION
# Description

Add full padding on zui table icon to circle gravatar correctly.

cf: Zoapp/front#115

## Type of change

- [X] Other (non-breaking change which doesn't match an issue, Non-code related, ...)

# How Has This Been Tested?

yarn test & lint have been launched.

**Test Configuration**:
* Yarn/npm/nodejs version: v1.12.3/v6.5.0/v8.10.0
* OS version: macOS 10.14.2
* Chrome version: Google Chrome 71.0.3578.98 

# Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have added tests that prove my fix is effective or that my feature works